### PR TITLE
Fix: close and clean the global instance plt in split_btd

### DIFF
--- a/dpnegf/negf/split_btd.py
+++ b/dpnegf/negf/split_btd.py
@@ -1317,7 +1317,7 @@ def show_blocks(subblocks, input_mat, results_path):
     plt.ylim(-1.0, input_mat.shape[0] - 0.5)
     plt.axis('off')
     plt.savefig(results_path +'/subblocks_HK0.png', dpi=300)
-
+    plt.close()
 
 # if __name__ == "__main__":
 #     import doctest


### PR DESCRIPTION
To suppress the RuntimeWarning about too many figures have been opened.