### PR TITLE
Feature&Refactor: support SCF restarts from given density matrices and several minor fixes

### DIFF
--- a/dpnegf/negf/lead_property.py
+++ b/dpnegf/negf/lead_property.py
@@ -705,8 +705,8 @@ def write_to_hdf5(h5_path, k, e, se):
         group_name = f"E_{e:.8f}"
         dset_name = f"k_{k[0]}_{k[1]}_{k[2]}"
         grp = f.require_group(group_name)
-        if dset_name in grp:
-            log.warning(f"Dataset {dset_name} already exists in group {group_name}. Skipping it.")
+        # if dset_name in grp:
+        #     log.warning(f"Dataset {dset_name} already exists in group {group_name}. Skipping it.")
         grp.create_dataset(dset_name, data=se.cpu().numpy(), compression="gzip")
         f.flush()
 
@@ -740,7 +740,7 @@ def merge_hdf5_files(tmp_dir, output_path, pattern, remove=True):
 
                     for dset_name in fin_group:
                         if dset_name in fout_group:
-                            log.warning(f"Dataset '{dset_name}' already exists in group '{group_name}'. Skipping.")
+                            # log.warning(f"Dataset '{dset_name}' already exists in group '{group_name}'. Skipping.")
                             continue
                         fin_group.copy(dset_name, fout_group)
 

--- a/dpnegf/negf/poisson_init.py
+++ b/dpnegf/negf/poisson_init.py
@@ -246,6 +246,7 @@ class Interface3D(object):
     Interface3D(grid, Dirichlet_group, dielectric_group)
     A class to handle the initialization and solution of the 3D Poisson equation
     on a structured grid with support for Dirichlet and dielectric regions.
+
     Parameters
     ----------
     grid : Grid
@@ -254,6 +255,7 @@ class Interface3D(object):
         List of Dirichlet region objects specifying boundary conditions.
     dielectric_group : list of Dielectric
         List of Dielectric region objects specifying spatially varying permittivity.
+        
     Attributes
     ----------
     Dirichlet_group : list

--- a/dpnegf/runner/NEGF.py
+++ b/dpnegf/runner/NEGF.py
@@ -182,7 +182,7 @@ class NEGF(object):
                                                                 meshgrid=self.stru_options[lead_tag]["kmesh_lead_Ef"],
                                                                 AtomicData_options=AtomicData_options,
                                                                 smearing_method=self.stru_options.get("e_fermi_smearing", "FD"),
-                                                                temp=100.0,
+                                                                temp=self.ele_T,
                                                                 eig_solver=self.stru_options.get("eig_solver", "torch"),)
         else:
             e_fermi["lead_L"] = self.e_fermi

--- a/dpnegf/runner/NEGF.py
+++ b/dpnegf/runner/NEGF.py
@@ -390,6 +390,9 @@ class NEGF(object):
                                                         dtype=self.poisson_options['poisson_dtype'])
                 log.info(msg="-------------------------------------------\n")
 
+            else:
+                log.info(msg="Using the given Poisson condition for NEGF-Poisson SCF")
+
             assert isinstance(pcond, Interface3D)
             self.poisson_negf_scf(interface_poisson=pcond,
                                   atom_gridpoint_index=list(pcond.grid.atom_index_dict.values()),

--- a/dpnegf/utils/argcheck.py
+++ b/dpnegf/utils/argcheck.py
@@ -1210,7 +1210,7 @@ def pyamg():
         Argument("dielectric_region", dict, optional=False, sub_fields=dielectric(), doc=doc_dielectric),
         *[
             Argument(f"dielectric_region{i}", dict, optional=True, sub_fields=dielectric(), doc=doc_dielectric)
-            for i in range(2, 6)
+            for i in range(2, 7)
         ],
         Argument("doped_region", dict, optional=False, sub_fields=doped(), doc=doc_doped)
     ]
@@ -1242,7 +1242,7 @@ def scipy():
         Argument("dielectric_region", dict, optional=True, sub_fields=dielectric(), doc=doc_dielectric),
         *[
             Argument(f"dielectric_region{i}", dict, optional=True, sub_fields=dielectric(), doc=doc_dielectric)
-            for i in range(2, 6)
+            for i in range(2, 7)
         ],
         Argument("doped_region1", dict, optional=True, sub_fields=doped(), doc=doc_doped),
         Argument("doped_region2", dict, optional=True, sub_fields=doped(), doc=doc_doped)


### PR DESCRIPTION
## What's changed
1. disable the warnings in lead_property.py
2. connect the ele_T (electronic temperature) user settings with smearing
3. support the externally given `pcond` as the initial guess of the Poisson-NEGF SCF
4. extend the upper limit on the number of regions by 1