### PR TITLE
Update GitHub Actions workflow with container image path fix and manual trigger

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -10,11 +10,12 @@ on:
       - 'docs/**'
       - 'examples/**'
       - 'README.md'
+  workflow_dispatch:
 
 jobs:
   build_and_push_container:
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'DeePTB-Lab'
+    if: github.repository_owner == 'deepmodeling'
 
     # 允许 GITHUB_TOKEN 有写入软件包（Packages）的权限，这是推送到 ghcr.io 所必需的
     permissions:

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'deepmodeling'
     # 使用由 'Container' 工作流构建的开发镜像
-    container: ghcr.io/deepmodeling/dpnegf-main:latest
+    container: ghcr.io/${{ github.repository_owner }}/dpnegf-main:latest
     steps: 
       - name: Checkout code
         uses: actions/checkout@v5


### PR DESCRIPTION
This pull request updates GitHub Actions workflows to improve flexibility and correct repository ownership checks. The main changes involve updating workflow triggers, repository owner conditions, and container image references to make the workflows more reusable and accurate for the `deepmodeling` organization.

**Workflow trigger and condition updates:**

* Added `workflow_dispatch` to `.github/workflows/devcontainer.yml` to allow manual triggering of the workflow.
* Changed the repository owner check in `.github/workflows/devcontainer.yml` from `'DeePTB-Lab'` to `'deepmodeling'` to ensure the workflow runs only for the correct organization.

**Container image reference improvement:**

* Updated the container image reference in `.github/workflows/unit_test.yml` to use a dynamic owner (`${{ github.repository_owner }}`) instead of a hardcoded value, making the workflow more flexible for forks and different organizations.