### PR TITLE
Update Dockerfile for DeePTB installation method

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,11 +36,11 @@ RUN \
     sed -i 's/build-backend = "poetry_dynamic_versioning.backend"/build-backend = "poetry.core.masonry.api"/' pyproject.toml && \
     conda create -n dpnegf python=3.10 -c conda-forge -y && \
     git clone https://github.com/deepmodeling/DeePTB.git && \
+    cd DeePTB && \
+    bash install.sh cpu && \
     conda run -n dpnegf pip install --upgrade pip setuptools wheel && \
-    conda run -n dpnegf pip install torch==2.1.1 --index-url https://download.pytorch.org/whl/cpu && \
-    conda run -n dpnegf pip install torch-scatter -f https://data.pyg.org/whl/torch-2.1.1+cpu.html && \
-    conda run -n dpnegf pip install ./DeePTB && \
-     conda run -n dpnegf pip install ./ && \
+    cd .. && \
+    conda run -n dpnegf pip install ./ && \
     conda clean --all -y && \
     rm -rf /root/.cache/pip
 


### PR DESCRIPTION
This pull request updates the installation steps in the `Dockerfile` to improve how the `DeePTB` dependency is installed. The main change is shifting from a direct pip install to running the `DeePTB` project's own installation script, which likely handles additional setup steps.

Dependency installation improvements:

* Changed the installation of `DeePTB` from a direct pip install to running its `install.sh` script with the `cpu` argument, ensuring any project-specific setup is executed. (`Dockerfile`, [DockerfileR39-R42](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R39-R42))
* Removed explicit installation of `torch` and `torch-scatter` via pip, likely because these are now handled by the `DeePTB` installation script. (`Dockerfile`, [DockerfileR39-R42](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R39-R42))